### PR TITLE
Added random state per frame

### DIFF
--- a/RayMarcher/RayMarchCompute.cu
+++ b/RayMarcher/RayMarchCompute.cu
@@ -84,7 +84,8 @@ __global__ void calculateMandelbulb(
 	Camera camera,
 	float exponent,
 	int numSamples,
-	Strategy shadingStrategy)
+	Strategy shadingStrategy,
+	unsigned long long seed)
 {
 	unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
 	unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
@@ -93,7 +94,7 @@ __global__ void calculateMandelbulb(
 
 	//TODO seed this with a random value
 	curandState state;
-	curand_init(1729, 0, 0, &state);
+	curand_init(seed + (x * y), 0, 0, &state);
 
 	float3 color = make_float3(0.0f);
 
@@ -134,7 +135,8 @@ void rayMarchDiffuseColour(
 	Camera camera,
 	float exponent,
 	int numSamples,
-	float3 colour)
+	float3 colour,
+	unsigned long long seed)
 {
 	DiffuseStrategy shadingStrategy{ colour };
 
@@ -146,7 +148,8 @@ void rayMarchDiffuseColour(
 		camera,
 		exponent,
 		numSamples,
-		shadingStrategy);
+		shadingStrategy,
+		seed);
 }
 
 void rayMarchNormalColour(
@@ -154,7 +157,8 @@ void rayMarchNormalColour(
 	dim3 texDim,
 	Camera camera,
 	float exponent,
-	int numSamples)
+	int numSamples,
+	unsigned long long seed)
 {
 	NormalStrategy shadingStrategy{};
 
@@ -166,7 +170,8 @@ void rayMarchNormalColour(
 		camera,
 		exponent,
 		numSamples,
-		shadingStrategy);
+		shadingStrategy,
+		seed);
 }
 
 void rayMarchStepwiseColour(
@@ -176,7 +181,8 @@ void rayMarchStepwiseColour(
 	float exponent,
 	int numSamples,
 	float3 lowColour,
-	float3 highColour)
+	float3 highColour,
+	unsigned long long seed)
 {
 	StepwiseStrategy shadingStrategy{ lowColour, highColour };
 
@@ -188,7 +194,8 @@ void rayMarchStepwiseColour(
 		camera,
 		exponent,
 		numSamples,
-		shadingStrategy);
+		shadingStrategy,
+		seed);
 }
 
 } // namespace rmcuda

--- a/RayMarcher/RayMarchCompute.cuh
+++ b/RayMarcher/RayMarchCompute.cuh
@@ -58,7 +58,8 @@ extern void rayMarchDiffuseColour(
 	Camera camera,
 	float exponent,
 	int numSamples,
-	float3 colour);
+	float3 colour,
+	unsigned long long seed);
 
 /**
 * Launches a ray marching computation on the supplied image agains a mandelbulb
@@ -76,7 +77,8 @@ extern void rayMarchNormalColour(
 	dim3 texDim,
 	Camera camera,
 	float exponent,
-	int numSamples);
+	int numSamples,
+	unsigned long long seed);
 
 /**
 * Launches a ray marching computation on the supplied image agains a mandelbulb
@@ -99,7 +101,8 @@ extern void rayMarchStepwiseColour(
 	float exponent,
 	int numSamples,
 	float3 lowColour,
-	float3 highColour);
+	float3 highColour,
+	unsigned long long seed);
 
 } // namespace compute
 } // namespace rmcuda

--- a/RayMarcher/RayMarcher.cpp
+++ b/RayMarcher/RayMarcher.cpp
@@ -36,6 +36,8 @@ RayMarcher::RayMarcher(const int width, const int height) :
   m_texture->cudaRegister();
 
   initUI();
+
+  m_randomState.seed(time(NULL));
 }
 
 void RayMarcher::run()
@@ -174,6 +176,8 @@ void RayMarcher::process(float deltaTime)
   checkResize();
   updateMultisamples();
 
+  unsigned long long randomSeed = m_distribution(m_randomState);
+
   switch (m_paramsInterface->getShadingMode())
   {
   case ShadingMode::kDiffuseLight:
@@ -184,7 +188,8 @@ void RayMarcher::process(float deltaTime)
       cam,
       exponent,
       m_numSamples,
-      make_float3(colour.r, colour.g, colour.b));
+      make_float3(colour.r, colour.g, colour.b),
+      randomSeed);
     break;
   }
   case ShadingMode::kNormalColor:
@@ -192,7 +197,8 @@ void RayMarcher::process(float deltaTime)
       compute::rayMarchNormalColour,
       cam,
       exponent,
-      m_numSamples);
+      m_numSamples,
+      randomSeed);
     break;
   case ShadingMode::kStepwiseShaded:
   {
@@ -204,7 +210,8 @@ void RayMarcher::process(float deltaTime)
       exponent,
       m_numSamples,
       make_float3(low.r, low.g, low.b),
-      make_float3(high.r, high.g, high.b));
+      make_float3(high.r, high.g, high.b),
+      randomSeed);
     break;
   }
   }

--- a/RayMarcher/RayMarcher.hpp
+++ b/RayMarcher/RayMarcher.hpp
@@ -15,6 +15,7 @@
 // std
 #include <vector>
 #include <memory>
+#include <random>
 
 // boost
 #include <boost/optional.hpp>
@@ -66,6 +67,10 @@ private:
 	int m_resizeHeight;
 
 	int m_numSamples = 1;
+
+	// random state
+	std::mt19937 m_randomState;
+	std::uniform_int_distribution<unsigned long long> m_distribution;
 };
 
 } // namespace rmcuda


### PR DESCRIPTION
Seeds a mersenne twister and uses it to generate random state for the kernel, instead of just using 1729 as the curand seed every time.